### PR TITLE
Add runinterval to puppetconf::baseconf::agent

### DIFF
--- a/manifests/baseconf/agent.pp
+++ b/manifests/baseconf/agent.pp
@@ -2,6 +2,7 @@
 class puppetconf::baseconf::agent ($master = undef,
   $conf_path = '/etc/puppetlabs/puppet/puppet.conf',
   $caserver = undef,
+  $runinterval = '30m',
   ){
 
   #the define types defaults
@@ -20,6 +21,10 @@ class puppetconf::baseconf::agent ($master = undef,
 
   puppetconf::main { 'ca_server':
     value     => $caserver,
+  }
+  
+  puppetconf::main { 'runinterval':
+    value     => $runinterval,
   }
 
   ## section agent config


### PR DESCRIPTION
None of the other agent options come through when using Puppet Enterprise. This is just added as a "quick fix" to include runinterval, but the remaining agent parameters should also be included at some point.