### PR TITLE
add support for global $environment variable and updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ Class `puppetconf::baseconf::agent`:
 <tr><td>master</td><td> = </td><td>undef</td></tr>
 <tr><td>caserver</td><td> = </td><td>undef</td></tr>
 <tr><td>conf_path</td><td> = </td><td>/etc/puppetlabs/puppet/puppet.conf</td></tr>
+<tr><td>environment</td><td> = </td><td>production</td></tr>
+<tr><td>runinterval</td><td> = </td><td>30m</td></tr>
 </table>
 <br/>
 

--- a/manifests/baseconf/agent.pp
+++ b/manifests/baseconf/agent.pp
@@ -3,7 +3,15 @@ class puppetconf::baseconf::agent ($master = undef,
   $conf_path = '/etc/puppetlabs/puppet/puppet.conf',
   $caserver = undef,
   $runinterval = '30m',
+  $environment = 'production',
   ){
+
+  if $::environment != undef {
+    $local_environment = $::environment
+  }
+  else {
+    $local_environment = $environment
+  }
 
   #the define types defaults
   Puppetconf::Main {
@@ -22,9 +30,13 @@ class puppetconf::baseconf::agent ($master = undef,
   puppetconf::main { 'ca_server':
     value     => $caserver,
   }
-  
+
   puppetconf::main { 'runinterval':
     value     => $runinterval,
+  }
+
+  puppetconf::main { 'environment':
+    value     => $local_environment,
   }
 
   ## section agent config


### PR DESCRIPTION
Simple tests ran successfully on puppet agent 6.5.0.
Added agent variables: environment and runinterval to README.md